### PR TITLE
Handles deletion and folder creation for Foundry v13

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -37,6 +37,10 @@
       "AutoCreateTempFolder": {
         "Name": "Automatically create folders?",
         "Hint": "Creates required folders whenever a GM user logs in."
+      },
+      "UseTempFolder": {
+        "Name": "Use temporary folder for imports?",
+        "Hint": "Imports will go into a temporary folder which you can then move things out of later. This is useful for allowing players to import their own characters without cluttering up the main actor directory with temporary actors created during munching."
       }
     },
     "Dialogs": {
@@ -140,7 +144,7 @@
     "Folders": {
       "Familiar": "Familiars",
       "Familiars": "Familiars",
-      "PathmuncherTemp": "PathmuncherTemp"
+      "PathmuncherTemp": "Pathmuncher Scratchpad"
     },
     "CompendiumGroups": {
       "feats": "Feats",

--- a/lang/en.json
+++ b/lang/en.json
@@ -33,6 +33,10 @@
         "Title": "Use custom compendium mappings?",
         "Label": "Custom Compendium Mappings",
         "Hint": "This is useful for things like Battlezoo or Cleric+ modules, or even if you have your own compendium of custom feats."
+      },
+      "AutoCreateTempFolder": {
+        "Name": "Automatically create folders?",
+        "Hint": "Creates required folders whenever a GM user logs in."
       }
     },
     "Dialogs": {
@@ -95,7 +99,8 @@
     },
     "Chat": {},
     "Notifications": {
-      "CreateActorPermission": "Pathmuncher requires the CREATE ACTOR permission for your user."
+      "CreateActorPermission": "Pathmuncher requires the CREATE ACTOR permission for your user.",
+      "CreateFolderError": "User {userName} lacks permission to create Folder {folderName}. Enable the setting or create it manually."
     },
     "Labels": {
       "Character": "Character details",
@@ -134,7 +139,8 @@
     },
     "Folders": {
       "Familiar": "Familiars",
-      "Familiars": "Familiars"
+      "Familiars": "Familiars",
+      "PathmuncherTemp": "PathmuncherTemp"
     },
     "CompendiumGroups": {
       "feats": "Feats",

--- a/src/app/Pathmuncher.js
+++ b/src/app/Pathmuncher.js
@@ -134,7 +134,7 @@ export class Pathmuncher {
     }
 
     this.immediateDiveAdd = utils.setting("USE_IMMEDIATE_DEEP_DIVE");
-    
+
     this.tempActorCounter = 1;
     this.tempActorFolderName = game.i18n.localize(`${CONSTANTS.FLAG_NAME}.Folders.PathmuncherTemp`);
   }
@@ -1027,7 +1027,7 @@ export class Pathmuncher {
       });
       throw err;
     } finally {
-      await this.#tryDeleteTempActor(tempActor);
+      await utils.deleteActor(tempActor);
     }
 
     logger.debug("Evaluate Choices failed", { choiceSet: cleansedChoiceSet, tempActor, document });
@@ -1088,7 +1088,7 @@ export class Pathmuncher {
       });
       throw err;
     } finally {
-      await this.#tryDeleteTempActor(tempActor);
+      await utils.deleteActor(tempActor);
     }
 
     logger.debug("Evaluate UUID failed", { choiceSet: cleansedRuleEntry, tempActor, document });
@@ -1145,7 +1145,7 @@ export class Pathmuncher {
       });
       throw err;
     } finally {
-      await this.#tryDeleteTempActor(tempActor);
+      await utils.deleteActor(tempActor);
     }
   }
 
@@ -1179,7 +1179,7 @@ export class Pathmuncher {
       });
       throw err;
     } finally {
-      await this.#tryDeleteTempActor(tempActor);
+      await utils.deleteActor(tempActor);
     }
   }
 
@@ -2841,29 +2841,16 @@ export class Pathmuncher {
   }
 
   #setTempActorName(actorData) {
-    if (!foundry.utils.isNewerVersion(game.version, CONSTANTS.TEMP_FOLDER_FOUNDRY_MIN_VERSION)) {
-      actorData.name = `Mr Temp (${this.result.character.name})`;
-      return;
-    }
-
     const formattedNum = this.tempActorCounter.toString().padStart(4, "0");
     actorData.name = `Mr Temp (${this.result.character.name}) ${formattedNum}`;
     this.tempActorCounter += 1;
   }
 
   async #setTempActorFolder(actorData) {
-    if (!foundry.utils.isNewerVersion(game.version, CONSTANTS.TEMP_FOLDER_FOUNDRY_MIN_VERSION)) {
-      return;
-    }
-    
+    if (!utils.setting("USE_TEMP_FOLDER")) return;
+
     let tempActorFolder = await utils.getOrCreateFolder(null, "Actor", this.tempActorFolderName);
     actorData.folder = tempActorFolder?.id;
-  }
-
-  async #tryDeleteTempActor(tempActor) {
-    if (tempActor.canUserModify(game.user, "delete")) {
-      await Actor.deleteDocuments([tempActor._id]);
-    }
   }
 
   async processCharacter() {
@@ -3085,14 +3072,6 @@ export class Pathmuncher {
     });
   }
 
-  static async removeTempActors() {
-    for (const actor of game.actors.filter((a) => foundry.utils.getProperty(a, "flags.pathmuncher.temp") === true)) {
-      if (actor.canUserModify(game.user, "delete")) {
-        await actor.delete();
-      }
-    }
-  }
-
   async updateActor() {
     await this.#removeDocumentsToBeUpdated();
 
@@ -3112,7 +3091,7 @@ export class Pathmuncher {
     await this.actor.update(this.result.character);
     await this.#createActorEmbeddedDocuments();
     await this.#restoreEmbeddedRuleLogic();
-    await Pathmuncher.removeTempActors();
+    await utils.removeTempActors();
   }
 
   async postImportCheck() {

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,6 +13,8 @@ const CONSTANTS = {
     USE_IMMEDIATE_DEEP_DIVE: "use-immediate-deep-dive",
     DISPLAY_TITLE: "display-title",
     AUTO_CREATE_TEMP_FOLDER: "auto-create-temp-folder",
+    USE_TEMP_FOLDER: "use-temp-folder",
+    ACTIVE_GM: "active-gm",
   },
 
   FEAT_PRIORITY: [
@@ -149,8 +151,6 @@ const CONSTANTS = {
     backgrounds: ["pf2e.backgrounds", "sf2e-anachronism.backgrounds", "pf2e-legacy-content.backgrounds-legacy"],
   },
 
-  TEMP_FOLDER_FOUNDRY_MIN_VERSION: "13",
-
   GET_DEFAULT_SETTINGS() {
     return foundry.utils.deepClone(CONSTANTS.DEFAULT_SETTINGS);
   },
@@ -166,6 +166,25 @@ CONSTANTS.DEFAULT_SETTINGS = {
     config: true,
     type: Boolean,
     default: true,
+  },
+
+  [CONSTANTS.SETTINGS.AUTO_CREATE_TEMP_FOLDER]: {
+    name: `${CONSTANTS.FLAG_NAME}.Settings.AutoCreateTempFolder.Name`,
+    hint: `${CONSTANTS.FLAG_NAME}.Settings.AutoCreateTempFolder.Hint`,
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: false,
+    onChange: debouncedReload,
+  },
+
+  [CONSTANTS.SETTINGS.USE_TEMP_FOLDER]: {
+    name: `${CONSTANTS.FLAG_NAME}.Settings.UseTempFolder.Name`,
+    hint: `${CONSTANTS.FLAG_NAME}.Settings.UseTempFolder.Hint`,
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: false,
   },
 
   [CONSTANTS.SETTINGS.RESTRICT_TO_TRUSTED]: {
@@ -219,14 +238,11 @@ CONSTANTS.DEFAULT_SETTINGS = {
     default: "WARN",
   },
 
-  [CONSTANTS.SETTINGS.AUTO_CREATE_TEMP_FOLDER]: {
-    name: `${CONSTANTS.FLAG_NAME}.Settings.AutoCreateTempFolder.Name`,
-    hint: `${CONSTANTS.FLAG_NAME}.Settings.AutoCreateTempFolder.Hint`,
+  [CONSTANTS.SETTINGS.ACTIVE_GM]: {
     scope: "world",
-    config: true,
-    type: Boolean,
-    default: false,
-    onChange: debouncedReload,
+    config: false,
+    type: String,
+    default: "",
   },
 
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,6 +12,7 @@ const CONSTANTS = {
     CUSTOM_COMPENDIUM_MAPPINGS: "custom-compendium-mappings",
     USE_IMMEDIATE_DEEP_DIVE: "use-immediate-deep-dive",
     DISPLAY_TITLE: "display-title",
+    AUTO_CREATE_TEMP_FOLDER: "auto-create-temp-folder",
   },
 
   FEAT_PRIORITY: [
@@ -148,6 +149,8 @@ const CONSTANTS = {
     backgrounds: ["pf2e.backgrounds", "sf2e-anachronism.backgrounds", "pf2e-legacy-content.backgrounds-legacy"],
   },
 
+  TEMP_FOLDER_FOUNDRY_MIN_VERSION: "13",
+
   GET_DEFAULT_SETTINGS() {
     return foundry.utils.deepClone(CONSTANTS.DEFAULT_SETTINGS);
   },
@@ -214,6 +217,16 @@ CONSTANTS.DEFAULT_SETTINGS = {
       OFF: `${CONSTANTS.FLAG_NAME}.Settings.LogLevel.off`,
     },
     default: "WARN",
+  },
+
+  [CONSTANTS.SETTINGS.AUTO_CREATE_TEMP_FOLDER]: {
+    name: `${CONSTANTS.FLAG_NAME}.Settings.AutoCreateTempFolder.Name`,
+    hint: `${CONSTANTS.FLAG_NAME}.Settings.AutoCreateTempFolder.Hint`,
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: false,
+    onChange: debouncedReload,
   },
 
 };

--- a/src/hooks/folder.js
+++ b/src/hooks/folder.js
@@ -1,0 +1,18 @@
+import { PathmuncherImporter } from "../app/PathmuncherImporter.js";
+import CONSTANTS from "../constants.js";
+import utils from "../utils.js";
+
+export function autoCreateFolders() {
+
+  const autoCreateEnabled = utils.setting("AUTO_CREATE_TEMP_FOLDER");
+  if (!autoCreateEnabled) return;
+  if (!game.user.isGM) return;
+
+  utils.getOrCreateFolder(null, "Actor", game.i18n.localize(`${CONSTANTS.FLAG_NAME}.Folders.Familiars`));
+  
+  if (foundry.utils.isNewerVersion(game.version, CONSTANTS.TEMP_FOLDER_FOUNDRY_MIN_VERSION))
+  {
+    utils.getOrCreateFolder(null, "Actor", game.i18n.localize(`${CONSTANTS.FLAG_NAME}.Folders.PathmuncherTemp`));
+  }
+
+}

--- a/src/hooks/folder.js
+++ b/src/hooks/folder.js
@@ -1,17 +1,13 @@
-import { PathmuncherImporter } from "../app/PathmuncherImporter.js";
 import CONSTANTS from "../constants.js";
 import utils from "../utils.js";
 
 export function autoCreateFolders() {
-
-  const autoCreateEnabled = utils.setting("AUTO_CREATE_TEMP_FOLDER");
-  if (!autoCreateEnabled) return;
+  if (!utils.setting("AUTO_CREATE_TEMP_FOLDER")) return;
   if (!game.user.isGM) return;
 
   utils.getOrCreateFolder(null, "Actor", game.i18n.localize(`${CONSTANTS.FLAG_NAME}.Folders.Familiars`));
-  
-  if (foundry.utils.isNewerVersion(game.version, CONSTANTS.TEMP_FOLDER_FOUNDRY_MIN_VERSION))
-  {
+
+  if (utils.setting("USE_TEMP_FOLDER")) {
     utils.getOrCreateFolder(null, "Actor", game.i18n.localize(`${CONSTANTS.FLAG_NAME}.Folders.PathmuncherTemp`));
   }
 

--- a/src/hooks/settings.js
+++ b/src/hooks/settings.js
@@ -1,5 +1,6 @@
 import { CompendiumSelector } from "../app/CompendiumSelector.js";
 import CONSTANTS from "../constants.js";
+import utils from "../utils.js";
 
 async function resetSettings() {
   for (const [name, data] of Object.entries(CONSTANTS.GET_DEFAULT_SETTINGS())) {
@@ -33,6 +34,16 @@ class ResetSettingsDialog extends FormApplication {
       },
       default: "cancel",
     });
+  }
+}
+
+export async function processActiveGM() {
+  // determine if this user is the active gm/first active in current session
+  if (game.user.isGM) {
+    const currentGMUser = game.users.get(utils.setting("ACTIVE_GM"));
+    if ((currentGMUser && !currentGMUser.active) || !currentGMUser) {
+      await utils.updateSetting("ACTIVE_GM", game.user.id);
+    }
   }
 }
 

--- a/src/module.js
+++ b/src/module.js
@@ -1,6 +1,7 @@
 import { registerAPI } from "./hooks/api.js";
 import { registerSettings } from "./hooks/settings.js";
 import { registerSheetButton } from "./hooks/sheets.js";
+import { autoCreateFolders } from "./hooks/folder.js";
 
 Hooks.once("init", () => {
   registerSettings();
@@ -9,4 +10,5 @@ Hooks.once("init", () => {
 Hooks.once("ready", () => {
   registerSheetButton();
   registerAPI();
+  autoCreateFolders();
 });

--- a/src/module.js
+++ b/src/module.js
@@ -1,14 +1,20 @@
 import { registerAPI } from "./hooks/api.js";
-import { registerSettings } from "./hooks/settings.js";
+import { registerSettings, processActiveGM } from "./hooks/settings.js";
 import { registerSheetButton } from "./hooks/sheets.js";
 import { autoCreateFolders } from "./hooks/folder.js";
+import utils from "./utils.js";
 
 Hooks.once("init", () => {
   registerSettings();
 });
 
-Hooks.once("ready", () => {
+Hooks.once("ready", async () => {
+  await processActiveGM();
   registerSheetButton();
   registerAPI();
   autoCreateFolders();
+  // cleanup temp actors on startup, but only for the active GM
+  if (utils.setting("ACTIVE_GM") === game.user.id) {
+    await utils.removeTempActors();
+  }
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -57,6 +57,20 @@ const utils = {
     // console.warn(`Looking for ${root} ${entityType} ${folderName}`);
     // console.warn(folder);
     if (folder) return folder;
+
+    if (!Folder.canUserCreate(game.user))
+    {
+      const errorMsg = game.i18n.format(
+        `${CONSTANTS.FLAG_NAME}.Notifications.CreateFolderError`,
+        {
+          userName: game.user.name,
+          folderName: folderName
+        }
+      );
+      ui.notifications.error(errorMsg);
+      throw new Error(errorMsg);
+    }
+
     folder = await Folder.create(
       {
         name: folderName,

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,18 +54,15 @@ const utils = {
       // if a root folder we want to match the root id for the parent folder
       && (root ? root.id : null) === (f.folder?.id ?? null),
     );
-    // console.warn(`Looking for ${root} ${entityType} ${folderName}`);
-    // console.warn(folder);
     if (folder) return folder;
 
-    if (!Folder.canUserCreate(game.user))
-    {
+    if (!Folder.canUserCreate(game.user)) {
       const errorMsg = game.i18n.format(
         `${CONSTANTS.FLAG_NAME}.Notifications.CreateFolderError`,
         {
           userName: game.user.name,
-          folderName: folderName
-        }
+          folderName: folderName,
+        },
       );
       ui.notifications.error(errorMsg);
       throw new Error(errorMsg);
@@ -108,6 +105,23 @@ const utils = {
 
   allowAncestryParagon: () => {
     return (foundry.utils.isNewerVersion("5.9.0", game.version) && game.settings.get("pf2e", "ancestryParagonVariant"));
+  },
+
+  async deleteActor(actor) {
+    if (actor.canUserModify(game.user, "delete")) {
+      await Actor.deleteDocuments([actor._id]);
+    }
+  },
+
+  async removeTempActors() {
+    const actorIds = game.actors
+      .filter((a) =>
+        foundry.utils.getProperty(a, "flags.pathmuncher.temp") === true
+        && a.canUserModify(game.user, "delete"),
+      )
+      .map((a) => a._id);
+    if (actorIds.length === 0) return;
+    await Actor.deleteDocuments(actorIds);
   },
 
 };


### PR DESCRIPTION
Summary of changes:
- Temp actors are created in a dedicated temp folder in Foundry v13 and above.
- Temp actors are only deleted if user has the permission.
- Custom error message when failing to create a Folder.
- Setting to automatically create required Folders. Defaults to false.

Links to #55 

---
### Current Behavior
_**In Foundry v12,**_ users with the "Create Actors" permission (`ACTOR_CREATE`) are also able to delete actors. The module is able to create and delete multiple temp actors while loading the character details, before finally assigning the data to the original actor. 

In case of a non-GM user importing a character with a familiar, that step fails with an error because they cannot create the "Familiars" folder.

_**In Foundry v13,**_ only GM level users can delete actors. This leads to the import failing with an error when the module attempts to delete the first temp actor. The folder creation limitation remains the same.

### New Behavior
_**In Foundry v12,**_ there are no changes to the temp actor naming or location. They continue to get created at the root level and are deleted automatically. A new custom error message is shown when a non-GM user fails to create the "Familiars" folder. This message informs the user to either manually create the folder or enable the setting.

A new setting is added that toggles automatic creation of the required folders. This is only the "Familiars" folder in v12. A hook is used to create this folder whenever a GM level user logs in and the setting is enabled. As long as the folder exists, a non-GM user will not receive any error during import.

_**In Foundry v13,**_ the setting also creates a second folder named "PathmuncherTemp". This location is used for all temp actors, and the actors are only deleted if the user has permission to do so. A number gets appended to the temp actor name (ex: "Mr Temp (LeafDruid) 0014") to help distinguish the stages. This might not be strictly necessary as the import process relies on ID and Foundry will allow duplicate actor names.

The setting is disabled by default to avoid introducing new folders to existing worlds where sheets are already set up.

---

I'm not familiar with the conventions around Foundry modules, so please let me know if creating folders in this way is alright. The main change will still work well without the setting and hook as long as GMs create those folders first.